### PR TITLE
Simplify include pattern for pypi tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-exclude *.txt *.py *.md
+exclude *.txt *.py *.md .DS_Store
 include CHANGES.txt CREDITS.txt LICENSE.txt VERSION.txt README.md setup.py
 recursive-include docs *
 recursive-exclude docs/_build *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 exclude *.txt *.py *.md
 include CHANGES.txt CREDITS.txt LICENSE.txt VERSION.txt README.md setup.py
-recursive-include docs *.*
+recursive-include docs *
 recursive-exclude docs/_build *
-recursive-include examples  *.*
-recursive-include tests *.py *.txt
+recursive-include examples  *
+recursive-include tests *
 exclude MANIFEST.in


### PR DESCRIPTION
The tarballs on pypi.python.org don't include all relevant files.

With this change the following files will be included in those tarballs too:

 * `docs/Makefile`
 * `tests/configs/copy_in_out.cfg`
 * `tests/data/cities.xml`