### PR TITLE
Various Stetl updates for NLExtract

### DIFF
--- a/stetl/etl.py
+++ b/stetl/etl.py
@@ -43,7 +43,7 @@ class ETL:
             sys.exit(1)
 
         ETL.CONFIG_DIR = os.path.dirname(os.path.abspath(config_file))
-        log.info("Config/working dir =%s" % ETL.CONFIG_DIR)
+        log.info("Config/working dir = %s" % ETL.CONFIG_DIR)
 
         self.configdict = ConfigParser()
 

--- a/stetl/filters/packetwriter.py
+++ b/stetl/filters/packetwriter.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Writes the payload of a packet as a string to a file.
+# Based on outputs.fileoutput.FileOutput.
+#
+# Author: Frank Steggink
+#
+from stetl.component import Config
+from stetl.filter import Filter
+from stetl.util import Util
+from stetl.packet import FORMAT
+
+import os
+
+log = Util.get_log('packetwriter')
+
+
+class PacketWriter(Filter):
+    """
+    Writes the payload of a packet as a string to a file.
+
+    consumes=FORMAT.any, produces=FORMAT.string
+    """
+
+    # Start attribute config meta
+    @Config(ptype=str, default=None, required=True)
+    def file_path(self):
+        """
+        File path to write content to.
+
+        Required: True
+
+        Default: None
+        """
+        pass
+
+    # End attribute config meta
+
+    # Constructor
+    def __init__(self, configdict, section):
+        Filter.__init__(self, configdict, section, consumes=FORMAT.any, produces=FORMAT.string)
+        log.info("working dir %s" % os.getcwd())
+
+    def invoke(self, packet):
+        if packet.data is None:
+            return packet
+
+        file_path = self.cfg.get('file_path')
+        return self.write_file(packet, file_path)
+
+    def write_file(self, packet, file_path):
+        log.info('writing to file %s' % file_path)
+        out_file = open(file_path, 'w')
+
+        out_file.write(packet.to_string())
+
+        out_file.close()
+        log.info("written to %s" % file_path)
+        
+        packet.data = file_path
+        return packet

--- a/stetl/filters/templatingfilter.py
+++ b/stetl/filters/templatingfilter.py
@@ -95,11 +95,11 @@ class StringTemplatingFilter(TemplatingFilter):
     contains the actual values to be substituted in the template string as a record (key/value pairs).
     Output is a regular string.
 
-    consumes=FORMAT.record, produces=FORMAT.string
+    consumes=FORMAT.record or FORMAT.record_array, produces=FORMAT.string
     """
 
     def __init__(self, configdict, section):
-        TemplatingFilter.__init__(self, configdict, section, consumes=FORMAT.record)
+        TemplatingFilter.__init__(self, configdict, section, consumes=[FORMAT.record, FORMAT.record_array])
 
     def create_template(self):
         # Init once
@@ -115,7 +115,11 @@ class StringTemplatingFilter(TemplatingFilter):
         self.template = Template(self.template_string)
 
     def render_template(self, packet):
-        packet.data = self.template.substitute(packet.data)
+        if type(packet.data) is list:
+            packet.data = [self.template.substitute(item) for item in packet.data]
+        else:
+            packet.data = self.template.substitute(packet.data)
+            
         return packet
 
 

--- a/stetl/filters/zipfileextractor.py
+++ b/stetl/filters/zipfileextractor.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Extracts a file from a ZIP file, and saves it as the given file name.
+#
+# Author: Frank Steggink
+#
+from stetl.component import Config
+from stetl.filter import Filter
+from stetl.util import Util
+from stetl.packet import FORMAT
+
+log = Util.get_log('zipfileextractor')
+
+
+class ZipFileExtractor(Filter):
+    """
+    Extracts a file from a ZIP file, and saves it as the given file name.
+
+    consumes=FORMAT.record, produces=FORMAT.string
+    """
+
+    # Start attribute config meta
+    @Config(ptype=str, default=None, required=True)
+    def file_path(self):
+        """
+        File name to write the extracted file to.
+
+        Required: True
+
+        Default: None
+        """
+        pass
+
+    # End attribute config meta
+
+    # Constructor
+    def __init__(self, configdict, section):
+        Filter.__init__(self, configdict, section, consumes=FORMAT.record, produces=FORMAT.string)
+        self.cur_file_path = self.cfg.get('file_path')
+
+    def invoke(self, packet):
+        event = None
+            
+        if packet.data is None:
+            log.info("No file name given")
+            return packet
+        
+        import os
+        import zipfile
+
+        with zipfile.ZipFile(packet.data['file_path']) as z:
+            with open(self.cur_file_path, 'wb') as f:
+                f.write(z.read(packet.data['name']))
+
+        packet.data = self.cur_file_path
+        return packet
+        
+    def after_chain_invoke(self, packet):
+        import os.path
+        if os.path.isfile(self.cur_file_path):
+            os.remove(self.cur_file_path)
+            
+        return True

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -570,9 +570,30 @@ class ZipFileInput(FileInput):
 
     def __init__(self, configdict, section):
         FileInput.__init__(self, configdict, section, produces=FORMAT.record)
+        self.file_content = None
         
-    def read_file(self, file_path):
-        import zipfile
+    def read(self, packet):
+        # No more files left and done with current file ?
+        if not(self.file_content) and not len(self.file_list):
+            packet.set_end_of_stream()
+            log.info("EOF file list, all files done")
+            return packet
+
+        # Done with current file or first file ?
+        if self.file_content is None:
+            self.cur_file_path = self.file_list.pop(0)
+
+            # Read file names
+            import zipfile
+            
+            zf = zipfile.ZipFile(self.cur_file_path, 'r')
+            self.file_content = [{'file_path': self.cur_file_path, 'name': name} for name in zf.namelist()]
+
+            log.info("zip file read : %s size=%d" % (self.cur_file_path, len(self.file_content)))
+
+        packet.data = self.file_content.pop(0)
         
-        zf = zipfile.ZipFile(file_path, 'r')
-        return [{'file_path': file_path, 'name': name} for name in zf.namelist()]
+        if not len(self.file_content):
+            self.file_content = None
+        
+        return packet

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -472,6 +472,7 @@ class JsonFileInput(FileInput):
 
         return file_data
 
+
 class ApacheLogFileInput(FileInput):
     """
     Parses Apache log files. Lines are converted into records based on the log format.
@@ -560,3 +561,18 @@ class ApacheLogFileInput(FileInput):
         return packet
 
 
+class ZipFileInput(FileInput):
+    """
+    Parse ZIP file from file system or URL into a stream of records containing file names.
+
+    produces=FORMAT.record
+    """
+
+    def __init__(self, configdict, section):
+        FileInput.__init__(self, configdict, section, produces=FORMAT.record)
+        
+    def read_file(self, file_path):
+        import zipfile
+        
+        zf = zipfile.ZipFile(file_path, 'r')
+        return [{'file_path': file_path, 'name': name} for name in zf.namelist()]

--- a/stetl/outputs/execoutput.py
+++ b/stetl/outputs/execoutput.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# Output classes for ETL, executing commands.
+#
+# Author: Frank Steggink
+#
+import subprocess
+import os
+import shutil
+from stetl.output import Output
+from stetl.util import Util
+from stetl.packet import FORMAT
+
+log = Util.get_log('execoutput')
+
+
+class ExecOutput(Output):
+    """
+    Executes any command (abstract base class).
+    """
+
+    def __init__(self, configdict, section, consumes):
+        Output.__init__(self, configdict, section, consumes)
+
+    def write(self, packet):
+        return packet
+
+    def execute_cmd(self, cmd):
+        use_shell = True
+        if os.name == 'nt':
+            use_shell = False
+
+        log.info("executing cmd=%s" % cmd)
+        subprocess.call(cmd, shell=use_shell)
+        log.info("execute done")
+
+        
+class Ogr2OgrExecOutput(ExecOutput):
+    """
+    Executes an Ogr2Ogr command.
+    Input is a file name to be processed.
+    Output by calling Ogr2Ogr command.
+
+    consumes=FORMAT.string
+    """
+
+    def __init__(self, configdict, section):
+        ExecOutput.__init__(self, configdict, section, consumes=FORMAT.string)
+
+        # For creating tables the GFS file needs to be newer than
+        # the .gml file. -lco GML_GFS_TEMPLATE somehow does not work
+        # so we copy the .gfs file each time with the .gml file with
+        # the same base name
+        self.lco = self.cfg.get('lco')
+        self.spatial_extent = self.cfg.get('spatial_extent')
+        options = self.cfg.get('options')
+        
+        dest_format = self.cfg.get('dest_format')
+        dest_data_source = self.cfg.get('dest_data_source')
+        
+        if not dest_format:
+            raise ValueError('Verplichte parameter dest_format ontbreekt')
+        if not dest_data_source:
+            raise ValueError('Verplichte parameter dest_data_source ontbreekt')
+                
+        self.ogr2ogr_cmd = 'ogr2ogr -f ' + dest_format + ' ' + dest_data_source
+        
+        if self.spatial_extent:
+            self.ogr2ogr_cmd += ' -spat ' + self.spatial_extent
+        if options:
+            self.ogr2ogr_cmd += ' ' + options
+            
+        self.first_run = True
+
+    def write(self, packet):
+        if packet.data is None:
+            return packet
+
+        # Execute ogr2ogr
+        ogr2ogr_cmd = self.ogr2ogr_cmd
+        if self.lco and self.first_run is True:
+            ogr2ogr_cmd += ' ' + self.lco
+            self.first_run = False
+
+        for item in packet.data:
+            # Append file name to command as last argument
+            self.execute_cmd(ogr2ogr_cmd + ' ' + item)
+        return packet

--- a/stetl/outputs/execoutput.py
+++ b/stetl/outputs/execoutput.py
@@ -125,6 +125,20 @@ class Ogr2OgrExecOutput(ExecOutput):
         """
         pass
 
+    @Config(ptype=bool, default=False, required=False)
+    def cleanup_input(self):
+        """
+        Flag to indicate whether the input file to ogr2ogr should be cleaned up.
+
+        Type: boolean
+
+        Required: False
+
+        Default: False
+        """
+
+        pass
+
     # End attribute config meta
 
     def __init__(self, configdict, section):
@@ -155,6 +169,7 @@ class Ogr2OgrExecOutput(ExecOutput):
             self.ogr2ogr_cmd += ' --config GML_GFS_TEMPLATE ' + gfs_template
         if options:
             self.ogr2ogr_cmd += ' ' + options
+        self.cleanup_input = self.cfg.get('cleanup_input')
             
         self.first_run = True
 
@@ -167,13 +182,21 @@ class Ogr2OgrExecOutput(ExecOutput):
         if self.lco and self.first_run is True:
             ogr2ogr_cmd += ' ' + self.lco
             self.first_run = False
+            
+        import os.path
 
         if type(packet.data) is list:
             for item in packet.data:
-                # Append file name to command as last argument
-                self.execute_cmd(ogr2ogr_cmd + ' ' + item)
+                self.execute(ogr2ogr_cmd, item)
         else:
-            # Append file name to command as last argument
-            self.execute_cmd(ogr2ogr_cmd + ' ' + packet.data)
+            self.execute(ogr2ogr_cmd, packet.data)
 
         return packet
+        
+    def execute(self, ogr2ogr_cmd, file_path):
+        # Append file name to command as last argument
+        self.execute_cmd(ogr2ogr_cmd + ' ' + file_path)
+            
+        if self.cleanup_input:
+            os.remove(file_path)
+    


### PR DESCRIPTION
For NLExtract it was desired to add the capability to read GML files directly from ZIP files, without extracting them upfront. In one case (BRK) data could be read with ogr2ogr through the use of the vsizip virtual file system. In another case, which needs extra processing (BGT, BRT), the GML files are being extracted one by one. This saves a lot of disk space on the file system from which the execution is run.

Furthermore, a new output class family has been introduced, namely ExecOutput. WIth this it is possible to execute commands, for example ogr2ogr (done with the Ogr2OgrExecOutput). I've also added a PacketWriter filter, which is basically the same as a FileOutput, except that it returns a file name in the package, so later processing can be done.

I've also modified the StringTemplatingFilter, because it is useful to apply a string template to a list at once, instead of one by one. However, this functionality is not used by (the nlextract_brk branch of) NLExtract anymore, but can be useful in other cases.