### PR TITLE
XmlElementReader added

### DIFF
--- a/stetl/etl.py
+++ b/stetl/etl.py
@@ -43,7 +43,7 @@ class ETL:
             sys.exit(1)
 
         ETL.CONFIG_DIR = os.path.dirname(os.path.abspath(config_file))
-        log.info("Config/working dir =%s" % ETL.CONFIG_DIR)
+        log.info("Config/working dir = %s" % ETL.CONFIG_DIR)
 
         self.configdict = ConfigParser()
 

--- a/stetl/filters/packetwriter.py
+++ b/stetl/filters/packetwriter.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Writes the payload of a packet as a string to a file.
+# Based on outputs.fileoutput.FileOutput.
+#
+# Author: Frank Steggink
+#
+from stetl.component import Config
+from stetl.filter import Filter
+from stetl.util import Util
+from stetl.packet import FORMAT
+
+import os
+
+log = Util.get_log('packetwriter')
+
+
+class PacketWriter(Filter):
+    """
+    Writes the payload of a packet as a string to a file.
+
+    consumes=FORMAT.any, produces=FORMAT.string
+    """
+
+    # Start attribute config meta
+    @Config(ptype=str, default=None, required=True)
+    def file_path(self):
+        """
+        File path to write content to.
+
+        Required: True
+
+        Default: None
+        """
+        pass
+
+    # End attribute config meta
+
+    # Constructor
+    def __init__(self, configdict, section):
+        Filter.__init__(self, configdict, section, consumes=FORMAT.any, produces=FORMAT.string)
+        log.info("working dir %s" % os.getcwd())
+
+    def invoke(self, packet):
+        if packet.data is None:
+            return packet
+
+        file_path = self.cfg.get('file_path')
+        return self.write_file(packet, file_path)
+
+    def write_file(self, packet, file_path):
+        log.info('writing to file %s' % file_path)
+        out_file = open(file_path, 'w')
+
+        out_file.write(packet.to_string())
+
+        out_file.close()
+        log.info("written to %s" % file_path)
+        
+        packet.data = file_path
+        return packet

--- a/stetl/filters/templatingfilter.py
+++ b/stetl/filters/templatingfilter.py
@@ -95,11 +95,11 @@ class StringTemplatingFilter(TemplatingFilter):
     contains the actual values to be substituted in the template string as a record (key/value pairs).
     Output is a regular string.
 
-    consumes=FORMAT.record, produces=FORMAT.string
+    consumes=FORMAT.record or FORMAT.record_array, produces=FORMAT.string
     """
 
     def __init__(self, configdict, section):
-        TemplatingFilter.__init__(self, configdict, section, consumes=FORMAT.record)
+        TemplatingFilter.__init__(self, configdict, section, consumes=[FORMAT.record, FORMAT.record_array])
 
     def create_template(self):
         # Init once
@@ -115,7 +115,11 @@ class StringTemplatingFilter(TemplatingFilter):
         self.template = Template(self.template_string)
 
     def render_template(self, packet):
-        packet.data = self.template.substitute(packet.data)
+        if type(packet.data) is list:
+            packet.data = [self.template.substitute(item) for item in packet.data]
+        else:
+            packet.data = self.template.substitute(packet.data)
+            
         return packet
 
 

--- a/stetl/filters/xmlelementreader.py
+++ b/stetl/filters/xmlelementreader.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+#
+# Reads an XML file and returns XML elements.
+# Based on inputs.fileinput.XmlElementStreamFileInput.
+#
+# Author: Frank Steggink
+#
+from stetl.component import Config
+from stetl.filter import Filter
+from stetl.util import Util, etree
+from stetl.packet import FORMAT
+
+log = Util.get_log('xmlelementreader')
+
+
+class XmlElementReader(Filter):
+    """
+    Extracts XML elements from a file, outputs each feature element in Packet.
+    Parsing is streaming (no internal DOM buildup) so any file size can be handled.
+    Use this class for your big GML files!
+
+    consumes=FORMAT.string, produces=FORMAT.etree_element
+    """
+
+    # Start attribute config meta
+    @Config(ptype=list, default=None, required=True)
+    def element_tags(self):
+        """
+        Comma-separated string of XML (feature) element tag names of the elements that should be extracted
+        and added to the output element stream.
+
+        Required: True
+
+        Default: None
+        """
+        pass
+
+    @Config(ptype=bool, default=False, required=False)
+    def strip_namespaces(self):
+        """
+        should namespaces be removed from the input document and thus not be present in the output element stream?
+
+        Required: False
+
+        Default: False
+        """
+        pass
+
+    # End attribute config meta
+
+    # Constructor
+    def __init__(self, configdict, section):
+        Filter.__init__(self, configdict, section, consumes=FORMAT.string, produces=FORMAT.etree_element)
+        self.context = None
+        self.root = None
+        self.cur_file_path = None
+        self.elem_count = 0
+        log.info("Element tags to be matched: %s" % self.element_tags)
+
+    def invoke(self, packet):
+        if packet.data is None:
+            log.info("No XML file given")
+            return packet
+
+        if self.cur_file_path is None:
+            self.cur_file_path = packet.data
+
+        event = None
+        packet.data = None
+        
+        if self.context is None:
+            # Open file
+            fd = open(self.cur_file_path)
+            self.elem_count = 0
+            log.info("file opened : %s" % self.cur_file_path)
+            self.context = etree.iterparse(fd, events=("start", "end"))
+            self.context = iter(self.context)
+            event, self.root = self.context.next()
+
+        packet = self.process_xml(packet)
+
+        return packet
+
+    def process_xml(self, packet):
+        while not self.context is None:
+            #while not packet.is_end_of_doc():
+            try:
+                event, elem = self.context.next()
+            except (etree.XMLSyntaxError, StopIteration):
+                # workaround for etree.XMLSyntaxError https://bugs.launchpad.net/lxml/+bug/1185701
+                self.context = None
+
+            if self.context is None:
+                # Always end of doc
+                # TODO: is this still useful for a non-input component?
+                packet.set_end_of_doc()
+                log.info("End of doc: %s elem_count=%d" % (self.cur_file_path, self.elem_count))
+
+                return packet
+
+            # Filter out Namespace from the tag
+            # this is the easiest way to go for now
+            tag = elem.tag.split('}')
+            if len(tag) == 2:
+                # Namespaced tag: 2nd is tag
+                tag = tag[1]
+            else:
+                # Non-namespaced tag: first
+                tag = tag[0]
+
+            if tag in self.element_tags:
+                if event == "start":
+                    # TODO check if deepcopy is the right thing to do here.
+                    # packet.data = elem
+                    pass
+                # self.root.remove(elem)
+                elif event == "end":
+                    # Delete the element from the tree
+                    # self.root.clear()
+                    packet.data = elem
+                    self.elem_count += 1
+                    self.root.remove(elem)
+
+                    if self.strip_namespaces:
+                        packet.data = Util.stripNamespaces(elem).getroot()
+
+            # If there is a next component, let it process
+            if self.next:
+                # Hand-over data (line, doc whatever) to the next component
+                packet.format = self._output_format
+                packet = self.next.process(packet)
+
+        return packet;
+        

--- a/stetl/filters/zipfileextractor.py
+++ b/stetl/filters/zipfileextractor.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Extracts a file from a ZIP file, and saves it as the given file name.
+#
+# Author: Frank Steggink
+#
+from stetl.component import Config
+from stetl.filter import Filter
+from stetl.util import Util
+from stetl.packet import FORMAT
+
+log = Util.get_log('zipfileextractor')
+
+
+class ZipFileExtractor(Filter):
+    """
+    Extracts a file from a ZIP file, and saves it as the given file name.
+
+    consumes=FORMAT.record, produces=FORMAT.string
+    """
+
+    # Start attribute config meta
+    @Config(ptype=str, default=None, required=True)
+    def file_path(self):
+        """
+        File name to write the extracted file to.
+
+        Required: True
+
+        Default: None
+        """
+        pass
+
+    # End attribute config meta
+
+    # Constructor
+    def __init__(self, configdict, section):
+        Filter.__init__(self, configdict, section, consumes=FORMAT.record, produces=FORMAT.string)
+        self.cur_file_path = self.cfg.get('file_path')
+
+    def invoke(self, packet):
+        event = None
+            
+        if packet.data is None:
+            log.info("No file name given")
+            return packet
+        
+        import os
+        import zipfile
+
+        with zipfile.ZipFile(packet.data['file_path']) as z:
+            with open(self.cur_file_path, 'wb') as f:
+                f.write(z.read(packet.data['name']))
+
+        packet.data = self.cur_file_path
+        return packet
+        
+    def after_chain_invoke(self, packet):
+        import os.path
+        if os.path.isfile(self.cur_file_path):
+            os.remove(self.cur_file_path)
+            
+        return True

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -570,9 +570,30 @@ class ZipFileInput(FileInput):
 
     def __init__(self, configdict, section):
         FileInput.__init__(self, configdict, section, produces=FORMAT.record)
+        self.file_content = None
         
-    def read_file(self, file_path):
-        import zipfile
+    def read(self, packet):
+        # No more files left and done with current file ?
+        if not(self.file_content) and not len(self.file_list):
+            packet.set_end_of_stream()
+            log.info("EOF file list, all files done")
+            return packet
+
+        # Done with current file or first file ?
+        if self.file_content is None:
+            self.cur_file_path = self.file_list.pop(0)
+
+            # Read file names
+            import zipfile
+            
+            zf = zipfile.ZipFile(self.cur_file_path, 'r')
+            self.file_content = [{'file_path': self.cur_file_path, 'name': name} for name in zf.namelist()]
+
+            log.info("zip file read : %s size=%d" % (self.cur_file_path, len(self.file_content)))
+
+        packet.data = self.file_content.pop(0)
         
-        zf = zipfile.ZipFile(file_path, 'r')
-        return [{'file_path': file_path, 'name': name} for name in zf.namelist()]
+        if not len(self.file_content):
+            self.file_content = None
+        
+        return packet

--- a/stetl/inputs/fileinput.py
+++ b/stetl/inputs/fileinput.py
@@ -472,6 +472,7 @@ class JsonFileInput(FileInput):
 
         return file_data
 
+
 class ApacheLogFileInput(FileInput):
     """
     Parses Apache log files. Lines are converted into records based on the log format.
@@ -560,3 +561,18 @@ class ApacheLogFileInput(FileInput):
         return packet
 
 
+class ZipFileInput(FileInput):
+    """
+    Parse ZIP file from file system or URL into a stream of records containing file names.
+
+    produces=FORMAT.record
+    """
+
+    def __init__(self, configdict, section):
+        FileInput.__init__(self, configdict, section, produces=FORMAT.record)
+        
+    def read_file(self, file_path):
+        import zipfile
+        
+        zf = zipfile.ZipFile(file_path, 'r')
+        return [{'file_path': file_path, 'name': name} for name in zf.namelist()]

--- a/stetl/outputs/execoutput.py
+++ b/stetl/outputs/execoutput.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# Output classes for ETL, executing commands.
+#
+# Author: Frank Steggink
+#
+import subprocess
+import os
+import shutil
+from stetl.output import Output
+from stetl.util import Util
+from stetl.packet import FORMAT
+
+log = Util.get_log('execoutput')
+
+
+class ExecOutput(Output):
+    """
+    Executes any command (abstract base class).
+    """
+
+    def __init__(self, configdict, section, consumes):
+        Output.__init__(self, configdict, section, consumes)
+
+    def write(self, packet):
+        return packet
+
+    def execute_cmd(self, cmd):
+        use_shell = True
+        if os.name == 'nt':
+            use_shell = False
+
+        log.info("executing cmd=%s" % cmd)
+        subprocess.call(cmd, shell=use_shell)
+        log.info("execute done")
+
+        
+class Ogr2OgrExecOutput(ExecOutput):
+    """
+    Executes an Ogr2Ogr command.
+    Input is a file name to be processed.
+    Output by calling Ogr2Ogr command.
+
+    consumes=FORMAT.string
+    """
+
+    def __init__(self, configdict, section):
+        ExecOutput.__init__(self, configdict, section, consumes=FORMAT.string)
+
+        # For creating tables the GFS file needs to be newer than
+        # the .gml file. -lco GML_GFS_TEMPLATE somehow does not work
+        # so we copy the .gfs file each time with the .gml file with
+        # the same base name
+        self.lco = self.cfg.get('lco')
+        self.spatial_extent = self.cfg.get('spatial_extent')
+        options = self.cfg.get('options')
+        
+        dest_format = self.cfg.get('dest_format')
+        dest_data_source = self.cfg.get('dest_data_source')
+        
+        if not dest_format:
+            raise ValueError('Verplichte parameter dest_format ontbreekt')
+        if not dest_data_source:
+            raise ValueError('Verplichte parameter dest_data_source ontbreekt')
+                
+        self.ogr2ogr_cmd = 'ogr2ogr -f ' + dest_format + ' ' + dest_data_source
+        
+        if self.spatial_extent:
+            self.ogr2ogr_cmd += ' -spat ' + self.spatial_extent
+        if options:
+            self.ogr2ogr_cmd += ' ' + options
+            
+        self.first_run = True
+
+    def write(self, packet):
+        if packet.data is None:
+            return packet
+
+        # Execute ogr2ogr
+        ogr2ogr_cmd = self.ogr2ogr_cmd
+        if self.lco and self.first_run is True:
+            ogr2ogr_cmd += ' ' + self.lco
+            self.first_run = False
+
+        for item in packet.data:
+            # Append file name to command as last argument
+            self.execute_cmd(ogr2ogr_cmd + ' ' + item)
+        return packet

--- a/stetl/outputs/execoutput.py
+++ b/stetl/outputs/execoutput.py
@@ -125,6 +125,20 @@ class Ogr2OgrExecOutput(ExecOutput):
         """
         pass
 
+    @Config(ptype=bool, default=False, required=False)
+    def cleanup_input(self):
+        """
+        Flag to indicate whether the input file to ogr2ogr should be cleaned up.
+
+        Type: boolean
+
+        Required: False
+
+        Default: False
+        """
+
+        pass
+
     # End attribute config meta
 
     def __init__(self, configdict, section):
@@ -155,6 +169,7 @@ class Ogr2OgrExecOutput(ExecOutput):
             self.ogr2ogr_cmd += ' --config GML_GFS_TEMPLATE ' + gfs_template
         if options:
             self.ogr2ogr_cmd += ' ' + options
+        self.cleanup_input = self.cfg.get('cleanup_input')
             
         self.first_run = True
 
@@ -167,13 +182,21 @@ class Ogr2OgrExecOutput(ExecOutput):
         if self.lco and self.first_run is True:
             ogr2ogr_cmd += ' ' + self.lco
             self.first_run = False
+            
+        import os.path
 
         if type(packet.data) is list:
             for item in packet.data:
-                # Append file name to command as last argument
-                self.execute_cmd(ogr2ogr_cmd + ' ' + item)
+                self.execute(ogr2ogr_cmd, item)
         else:
-            # Append file name to command as last argument
-            self.execute_cmd(ogr2ogr_cmd + ' ' + packet.data)
+            self.execute(ogr2ogr_cmd, packet.data)
 
         return packet
+        
+    def execute(self, ogr2ogr_cmd, file_path):
+        # Append file name to command as last argument
+        self.execute_cmd(ogr2ogr_cmd + ' ' + file_path)
+            
+        if self.cleanup_input:
+            os.remove(file_path)
+    


### PR DESCRIPTION
I've added a new filter XmlElementReader with which an XML file can be read element by element. It has the same XML reading functionality as an XmlElementStreamerFileInput, but since it only contains this functionality, it is more versatile. In NLExtract there is a use case to read XML files from a ZIP file first, and then pass element by element.

This file wasn't included in pull request #28, because here I'm diverging from the standard Stetl architecture that only Component.process is calling process on its next component. If I omit the functionality, only one iteration of the XML parsing is done, but I want to parse the entire file and load it somewhere, before the next file can be read.

Please process pull request #28 before this pull request is being processed!