### PR TITLE
Replacing the GML_GFS_TEMPLATE config option by copying the GFS template again

### DIFF
--- a/stetl/outputs/execoutput.py
+++ b/stetl/outputs/execoutput.py
@@ -149,8 +149,8 @@ class Ogr2OgrExecOutput(ExecOutput):
         # so we copy the .gfs file each time with the .gml file with
         # the same base name
         self.lco = self.cfg.get('lco')
+        self.gfs_template = self.cfg.get('gfs_template')
         spatial_extent = self.cfg.get('spatial_extent')
-        gfs_template = self.cfg.get('gfs_template')
         options = self.cfg.get('options')
         
         dest_format = self.cfg.get('dest_format')
@@ -165,8 +165,6 @@ class Ogr2OgrExecOutput(ExecOutput):
         
         if spatial_extent:
             self.ogr2ogr_cmd += ' -spat ' + spatial_extent
-        if gfs_template:
-            self.ogr2ogr_cmd += ' --config GML_GFS_TEMPLATE ' + gfs_template
         if options:
             self.ogr2ogr_cmd += ' ' + options
         self.cleanup_input = self.cfg.get('cleanup_input')
@@ -194,9 +192,18 @@ class Ogr2OgrExecOutput(ExecOutput):
         return packet
         
     def execute(self, ogr2ogr_cmd, file_path):
+        # Copy the .gfs file if required, use the same base name
+        # so ogr2ogr will pick it up.
+        if self.gfs_template:
+            file_ext = os.path.splitext(file_path)
+            gfs_path = file_ext[0] + '.gfs'
+            shutil.copy(self.gfs_template, gfs_path)
+            
         # Append file name to command as last argument
         self.execute_cmd(ogr2ogr_cmd + ' ' + file_path)
             
         if self.cleanup_input:
             os.remove(file_path)
+            if self.gfs_template:
+                os.remove(gfs_path)
     


### PR DESCRIPTION
The reason for this change in Ogr2OgrExecOutput is that with GDAL/OGR 1.11 it appears that many feature types didn't have the correct geometry type registered, even though they are entered correctly in the GFS file. I was able to solve this by copying the GFS template to the same dir and with the same name as the XML file which is being read by ogr2ogr. This is the same method used in Ogr2OgrOutput.

It is strange that a few geometry types are registered correctly. With the BGT only a handful (about 5) of all feature types (41) are registered correctly. The rest is shown as GEOMETRY in the geometry_columns view in PostGIS. With TOP10NL more than half was registered correctly, but not all of them.

I suspect this has something to do with the layer creation options (-lco). I haven't tested the behaviour with GDAL/OGR version 2.0. I think it might be still too early to switch to this version, so I just applied this as a fix. I'll open an issue to start the discussion about the GDAL/OGR version.