### PR TITLE
Don't install libproj explicitly.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update && \
 RUN apt-add-repository ppa:ubuntugis/ubuntugis-unstable
 RUN apt-get update && \
 	apt-get install -y git \
-    libproj0 \
     libgeos-dev \
     python-lxml \
     python-gdal \


### PR DESCRIPTION
libproj-dev depends on its respective libproj library package, no need to install it explicitly.

libproj-dev is a dependency of libgdal-dev, installing that is sufficient.

The proj library package name has changed to reflect the SONAME bump in PROJ 4.9.1-rc3, and will change again for PROJ 4.9.3.

libproj0 was used until PROJ 4.9.1-rc3.
libproj9 is currently used, and will change to libproj11 in 4.9.3.